### PR TITLE
Dependency update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM debian:wheezy
+FROM nginx
 
 MAINTAINER vadim@yummly.com
 
-ENV NODE_VERSION v0.10.36
+ENV NODE_VERSION v0.10.39
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get -qq update && \
-    apt-get -q -y install dnsmasq nginx supervisor openssh-server daemontools logrotate curl make g++ && \
+    apt-get -q -y install dnsmasq supervisor daemontools logrotate curl make g++ && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
     sed -i -e 's/# *user.*$/user=root\n/' /etc/dnsmasq.conf && \
     curl -s -S -L http://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-x64.tar.gz | tar -xzf - -C /opt && \


### PR DESCRIPTION
- Use nginx base image, which bring in debian jessie + most recent nginx
- Use node 0.10.39, the latest version on the 0.10 branch

Website process build from this is on http://vadim-web.development.yummly.com
